### PR TITLE
Preserve quotes in shell expressions

### DIFF
--- a/devassistant/lang.py
+++ b/devassistant/lang.py
@@ -285,7 +285,7 @@ class Interpreter(object):
                 # literals
                 symbol = self.symbol_table["(literal)"]
                 s = symbol()
-                s.value = tok.strip('"')
+                s.value = tok
                 yield s
             else:
                 if not self.in_shell:
@@ -360,7 +360,7 @@ def evaluate_expression(expression, names):
         for v in reversed(sorted(interpr.names.keys())):
             self.value = self.value.replace("$" + v, str(interpr.names[v]))
 
-        return bool(self.value), self.value
+        return bool(self.value.strip('"')), self.value.strip('"')
 
     @interpr.method("and")
     def led(self, left):

--- a/test/test_lang.py
+++ b/test/test_lang.py
@@ -98,6 +98,7 @@ class TestEvaluate(object):
         #assert re.match(".*/foo/bar$",
         #               evaluate_expression("$(cd foo; cd bar; pwd; cd ../..)",
         #                                   self.names)[1])
+        assert evaluate_expression('$(echo -e "foo\\nbar" | grep "bar")', self.names) == (True, "bar")
 
     def test_literal(self):
         assert evaluate_expression('"foobar"', self.names) == (True, "foobar")


### PR DESCRIPTION
Resolves bkabrda/devassistant#131. The issue was that the tokenizer
would recognize quoted strings as literals, and thus stripped
the quotes, before realizing that it is in shell expression and
should thus treat all tokens verbatim.

After this commit it is no longer the tokenizer that does the stripping,
it is instead the nud function of the (literal) token, which makes
more sense anyway.
