### PR TITLE
ListStore needs have a str or GOBject otherwise TraceBack

### DIFF
--- a/devassistant/command_helpers.py
+++ b/devassistant/command_helpers.py
@@ -411,7 +411,7 @@ class GtkDialogHelper(object):
         cls.info_btn = cls._get_button('Show packages')
         cls.show = True
         cls.info_btn.connect('clicked', cls._info_installed_packages(win))
-        liststore = Gtk.ListStore(six.text_type)
+        liststore = Gtk.ListStore(str)
         for pkg in sorted(package_list):
             liststore.append([pkg])
         listview = Gtk.TreeView(liststore)


### PR DESCRIPTION
if six.text_type is used then following traceback is seen.
  File "/home/phracek/work/programming/devassistant/devassistant/command_helpers.py", line 414, in ask_for_package_list_confirm
    liststore = Gtk.ListStore(six.text_type)
  File "/usr/lib64/python2.7/site-packages/gi/overrides/Gtk.py", line 932, in **init**
    self.set_column_types(column_types)
TypeError: Item 0: Must be gobject.GType, not type

After changing back to str all works fine.
It was caused by commit (https://github.com/bkabrda/devassistant/commit/90f0929524365ba7d088de7b00d3d2076efc2a16)
