### PR TITLE
Preliminary support for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ sdist
 develop-eggs
 .installed.cfg
 
+# varenv
+.env
+
 # Installer logs
 pip-log.txt
 

--- a/devassistant/settings.py
+++ b/devassistant/settings.py
@@ -32,4 +32,5 @@ SYSTEM_DEPTYPES_SHORTCUTS = {'rpm': ['fedora', 'red hat enterprise linux'],
                              'pacman': ['arch'],
                              # NOTE /etc/os-release has ID=gentoo,
                              # but platform.distribution reports "Gentoo Base System" string
-                             'ebuild': ['gentoo', 'gentoo base system']}
+                             'ebuild': ['gentoo', 'gentoo base system'],
+                             'homebrew': ['darwin', 'OS X']}

--- a/devassistant/utils.py
+++ b/devassistant/utils.py
@@ -32,7 +32,14 @@ def get_system_version():
 
 
 def get_distro_name():
+  system = get_system_name()
+  if system == 'linux':
     return platform.linux_distribution()[0].lower() or _get_os_release_content('ID')
+  elif system == 'darwin':
+      return 'darwin'
+  else:
+      return ''
+
 
 
 def get_distro_version():

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -165,7 +165,7 @@ class TestCache(object):
         self.addme_copy('addme_change_fullname.yaml', 'assistants/crt/addme.yaml')
         self.create_or_refresh_cache()
         assert addme['attrs']['fullname'] == 'Fullname changed!'
-        
+
         # change current snippet (will change argument flag)
         # snippets are cached during one startup => reset snippet cache manually
         # TODO: fix this ^^

--- a/test/test_command_helpers.py
+++ b/test/test_command_helpers.py
@@ -53,7 +53,8 @@ class TestClHelper(object):
     def test_run_command_cd(self):
         cwd = os.getcwd()
         try:
-            tmpdir = tempfile.gettempdir()
+            # On OSX, /etc is a link to /private/etc, hence the realpath call
+            tmpdir = os.path.realpath(tempfile.gettempdir())
             out = ClHelper.run_command('cd {0}'.format(tmpdir))
             assert out == ''
             assert os.getcwd() == tmpdir

--- a/test/test_lang.py
+++ b/test/test_lang.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import re
 
 from devassistant.exceptions import YamlSyntaxError
 from devassistant.lang import Command, evaluate_expression, exceptions, \
@@ -347,11 +348,12 @@ class TestRunSection(object):
     def test_assign_unsuccessful_command(self):
         kwargs = {}
         run_section([{'$foo~': '$(ls spam/spam/spam)'}], kwargs)
-        assert kwargs['foo'] == u'ls: cannot access spam/spam/spam: No such file or directory'
+        assert re.match(r'ls:.* spam/spam/spam: No such file or directory', kwargs['foo'], re.I|re.M)
 
         # both logical result and result
         run_section([{'$success, $val~': '$(ls spam/spam/spam)'}], kwargs)
-        assert kwargs['val'] == u'ls: cannot access spam/spam/spam: No such file or directory'
+        # assert kwargs['val'] == u'ls: cannot access spam/spam/spam: No such file or directory'
+        assert re.match(r'ls:.* spam/spam/spam: No such file or directory', kwargs['val'], re.I|re.M)
         assert kwargs['success'] == False
 
     def test_assing_string_with_escaped_exec_flag(self):

--- a/test/test_yaml_loader.py
+++ b/test/test_yaml_loader.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from devassistant.yaml_loader import YamlLoader
 
@@ -15,7 +16,8 @@ class TestYamlLoader(object):
         self.tlh = TestLoggingHandler.create_fresh_handler()
 
     def test_load_yaml_by_path_logs_and_returns_None_on_bad_syntax(self):
-        e = 'Yaml error in {s} (line 0, column 3): mapping values are not allowed in this context'.\
+        e = 'Yaml error in {s} \(line 0, column 3\): mapping values are not allowed (in this context|here)'.\
                 format(s=self.bad_syntax)
         assert YamlLoader.load_yaml_by_path(self.bad_syntax) == None
-        assert ('WARNING', e) in self.tlh.msgs
+        assert 'WARNING' == self.tlh.msgs[0][0]
+        assert re.match(e, self.tlh.msgs[0][1])


### PR DESCRIPTION
Hi there,

I just started an attempt at being able to use devassistant on OSX, using Homebrew as package manager.
In the current state, it works with dedicated assistants (i.e. I did not yet add all the 'homebre' dependencies in the assistants) and 2 tests are failing (but it seems they're failing as well on my docker container).

A preliminary dependency is `sed` (i.e. `brew install sed --default-names`) as the assistants are written with the GNU sed in mind.
Note also that in some cases I do think the assistants need to be reviewed (i.e. regarding rails for example, it is considered as bad practice to install the platform version. People are usually installing the needed rails version locally thanks to `bundler`)

Regards
