### PR TITLE
Fix 'cd' command to handle whitespace.

### DIFF
--- a/devassistant/command_helpers.py
+++ b/devassistant/command_helpers.py
@@ -48,8 +48,10 @@ class ClHelper(object):
         if cmd_str.startswith('cd '):
             # special-case cd to behave like shell cd and stay in the directory
             try:
-                # delete any qoutes, the quoting is automatical in os.chdir
-                directory = cmd_str.split()[1].replace('"', '').replace('\'', '')
+                directory = cmd_str[3:]
+                # delete any quotes, os.chdir doesn't split words like sh does
+                if directory[0] == directory[-1] == '"':
+                    directory = directory[1:-1]
                 os.chdir(directory)
             except OSError as e:
                 raise exceptions.ClException(cmd_str, 1, six.text_type(e))


### PR DESCRIPTION
Don't use cmd_str.split()[1] because it fails if the directory name
contains whitespace.

This fixes the primary issue in https://bugzilla.redhat.com/show_bug.cgi?id=1092682
