### PR TITLE
Minor documentation tweaks.

### DIFF
--- a/docs/developer_documentation/command_reference.rst
+++ b/docs/developer_documentation/command_reference.rst
@@ -3,19 +3,19 @@
 Command Reference
 =================
 
-This page serves as a reference commands of DevAssistant Yaml DSL.
-Every command consists of **command_type** and **command_input**. After it gets executed,
-it sets ``LAST_LRES`` and ``LAST_RES`` variables. These are also its return values,
+This page serves as a reference for commands of the DevAssistant Yaml DSL.
+Every command consists of a **command_type** and **command_input**. After it gets executed,
+it sets the ``LAST_LRES`` and ``LAST_RES`` variables. These are also its return values,
 similar to :ref:`expressions_ref` **logical result** and **result**.
 
-- ``LAST_LRES`` is a logical result of the run - ``True``/``False`` if successful/unsuccessful
-- ``LAST_RES`` is a "return value" - e.g. a computed value
+- ``LAST_LRES`` is the logical result of the run - ``True``/``False`` if successful/unsuccessful
+- ``LAST_RES`` is the "return value" - e.g. a computed value
 
 In the Yaml DSL, commands are called like this::
 
    command_type: command_input
 
-This reference summarizes commands included in DevAssistant itself in following format:
+This reference summarizes commands included in DevAssistant itself in the following format:
 
 ``command_type`` - some optional info
 
@@ -24,7 +24,7 @@ This reference summarizes commands included in DevAssistant itself in following 
 - LRES: what is ``LAST_LRES`` set to after this command?
 - Example: example usage
 
-*Missing something?* Commands are your entrypoint for extending DevAssistant.
+*Missing something?* Commands are your entry point for extending DevAssistant.
 If you're missing some functionality in ``run`` sections, just
 :ref:`write a command runner <command_runners>` and send us a pull request.
 

--- a/docs/developer_documentation/devassistant_core.rst
+++ b/docs/developer_documentation/devassistant_core.rst
@@ -123,7 +123,7 @@ than DevAssistant will print out something like::
    INFO: MyCommandRunner was invoked: mycomm: You are using DevAssistant!
 
 When run, this command returns a tuple with *logical result* and *result*. This means
-you can assign the length of string to variable like this::
+you can assign the length of a string to a variable like this::
 
    run:
    $thiswillbetrue, $length~:

--- a/docs/developer_documentation/run_sections_reference.rst
+++ b/docs/developer_documentation/run_sections_reference.rst
@@ -65,8 +65,8 @@ the basic usage of the most important commands here. Note, that when you use var
 
   Loops probably also work as you'd expect - they've got the control variable and an "iterator".
   Loop iterators are **expressions**, see :ref:`expressions_ref`. Note, that you can use two
-  forms of for loop. If you use ``word_in``, DevAssistant will split given expression on
-  whitespaces and then iterate over that, while if you use ``in``, DevAssistant will iterate
+  forms of for loop. If you use ``word_in``, DevAssistant will split the given expression on
+  whitespace and then iterate over that, while if you use ``in``, DevAssistant will iterate
   over single characters of the string.
 
 - variable assignment::


### PR DESCRIPTION
Something I didn't change: Where it says _'they've got the control variable and an "iterator"'_ in `docs/developer_documentation/run_sections_reference.rst` should that be "iterable" not "iterator"?
