### PR TITLE
Fix failure when an SSH key comment contains non-ascii characters.

### DIFF
--- a/devassistant/remote_auth.py
+++ b/devassistant/remote_auth.py
@@ -1,5 +1,6 @@
 import getpass
 import glob
+import io
 import os
 
 import six
@@ -192,7 +193,7 @@ class GitHubAuth(object):
         pubkey_files = glob.glob(os.path.expanduser('~/.ssh/*.pub'))
         for rk in remote_keys:
             for pkf in pubkey_files:
-                local_key = open(pkf).read()
+                local_key = io.open(pkf, encoding='utf-8').read()
                 # in PyGithub 1.23.0, remote key is an object, not string
                 rkval = rk if isinstance(rk, six.string_types) else rk.value
                 # don't use "==" because we have comments etc added in public_key


### PR DESCRIPTION
This is an attempt to fix #338.

The problem described in #338 is only present when using Python2. The `local_key` variable ([link](https://github.com/devassistant/devassistant/blob/86169d816c2ed1f0ff9335d31b50068038242173/devassistant/remote_auth.py#L195)) has type `str`, while the `rkval` variable ([link](https://github.com/devassistant/devassistant/blob/86169d816c2ed1f0ff9335d31b50068038242173/devassistant/remote_auth.py#L197)) has type `unicode`. When testing the condition of the [if statement](https://github.com/devassistant/devassistant/blob/86169d816c2ed1f0ff9335d31b50068038242173/devassistant/remote_auth.py#L199), this fails with:
```
UnicodeDecodeError: 'ascii' codec can't decode byte ... in position ...: ordinal not in range(128)
```
when `local_key` contains non-ascii characters.

To overcome this and make it work on both, Python2 and Python3, I went with `io.open()` and set the `encoding` argument to `utf-8`.
In combination with `read()`, this returns `unicode` with Python2 and `str` with Python3. This then fixes the failing `if` condition and makes the problem go away.

Questions:
- Is it OK to assume that public SSH key files are encoded with `utf-8`?
- Should we write a test case for #338 to prevent such regression in the future?