### PR TITLE
Add __main__.py to make package executable

### DIFF
--- a/devassistant/__main__.py
+++ b/devassistant/__main__.py
@@ -1,0 +1,3 @@
+from devassistant.cli.cli_runner import CliRunner
+
+CliRunner.run()


### PR DESCRIPTION
`python -m devassistant` when it is not available from PATH.