### PR TITLE
dapicli.py: os.geteuid is absent on Windows

### DIFF
--- a/devassistant/cli/cli_runner.py
+++ b/devassistant/cli/cli_runner.py
@@ -3,6 +3,13 @@ import os
 import sys
 import six
 
+try:
+    # try to enable ANSI colors in Windows
+    import colorama
+    colorama.init()
+except ImportError:
+    pass
+
 from devassistant import actions
 from devassistant import bin
 from devassistant.cli import argparse_generator

--- a/devassistant/dapi/dapicli.py
+++ b/devassistant/dapi/dapicli.py
@@ -32,7 +32,7 @@ def _install_path():
         if path.endswith('/'):
             return os.path.expanduser(path[:-1])
         return os.path.expanduser(path)
-    if os.geteuid() == 0:
+    if getattr(os, 'geteuid', None) != None and os.geteuid() == 0:
         return DAPI_DEFAULT_ROOT_INSTALL
     return os.path.expanduser(DAPI_DEFAULT_USER_INSTALL)
 


### PR DESCRIPTION
This allows to get command line help on this platform