### PR TITLE
Use mirror when DAPI is unavailable

### DIFF
--- a/devassistant/dapi/dapicli.py
+++ b/devassistant/dapi/dapicli.py
@@ -76,16 +76,19 @@ def _get_from_dapi_or_mirror(link):
 
     return req
 
-def data(link):
-    '''Returns a dictionary from requested link'''
-    # Remove the API URL from the link if it is there
-    # So we can swap it with mirror
-    # It gets there sometimes by using data() directly on items from previous API calls
+
+def _remove_api_url_from_link(link):
+    '''Remove the API URL from the link if it is there'''
     if link.startswith(_api_url()):
         link = link[len(_api_url()):]
     if link.startswith(_api_url(mirror=True)):
         link = link[len(_api_url(mirror=True)):]
+    return link
 
+
+def data(link):
+    '''Returns a dictionary from requested link'''
+    link = _remove_api_url_from_link(link)
     req = _get_from_dapi_or_mirror(link)
     return _process_req(req)
 

--- a/devassistant/dapi/dapicli.py
+++ b/devassistant/dapi/dapicli.py
@@ -20,12 +20,15 @@ try:
 except:
     from yaml import Loader
 from devassistant.settings import DAPI_API_URL
+from devassistant.settings import DAPI_API_MIRROR_URL
 from devassistant.settings import DATA_DIRECTORIES
 from devassistant.settings import DEVASSISTANT_HOME
 from devassistant.settings import DISTRO_DIRECTORY
 
 
-def _api_url():
+def _api_url(mirror=False):
+    if mirror:
+        return DAPI_API_MIRROR_URL
     return DAPI_API_URL
 
 
@@ -58,6 +61,8 @@ def data(link):
     # It gets there sometimes by using data() directly on items from previous API calls
     if link.startswith(_api_url()):
         link = link[len(_api_url()):]
+    if link.startswith(_api_url(mirror=True)):
+        link = link[len(_api_url(mirror=True)):]
     # Now put the API URL back, we removed it for nothing :D
     req = requests.get(_api_url() + link)
     return _process_req(req)

--- a/devassistant/dapi/dapicli.py
+++ b/devassistant/dapi/dapicli.py
@@ -53,13 +53,19 @@ def _process_req(req):
 
 def data(link):
     '''Returns a dictionary from requested link'''
-    req = requests.get(link)
+    # Remove the API URL from the link if it is there
+    # So we can swap it with mirror
+    # It gets there sometimes by using data() directly on items from previous API calls
+    if link.startswith(_api_url()):
+        link = link[len(_api_url()):]
+    # Now put the API URL back, we removed it for nothing :D
+    req = requests.get(_api_url() + link)
     return _process_req(req)
 
 
 def _unpaginated(what):
     '''Returns a dictionary with all <what>, unpaginated'''
-    page = data(_api_url() + what)
+    page = data(what)
     results = page['results']
     count = page['count']
     while page['next']:
@@ -86,19 +92,19 @@ def daps():
 
 def user(username=''):
     '''Returns a dictionary with all info about a given user'''
-    return data(_api_url() + 'users/' + username + '/')
+    return data('users/' + username + '/')
 
 
 def metadap(name):
     '''Returns a dictionary with all info about a given metadap'''
-    return data(_api_url() + 'metadaps/' + name + '/')
+    return data('metadaps/' + name + '/')
 
 
 def dap(name, version=''):
     '''Returns a dictionary with all info about a given dap'''
     if version:
         name += '-' + version
-    return data(_api_url() + 'daps/' + name + '/')
+    return data('daps/' + name + '/')
 
 
 def search(query):

--- a/devassistant/settings.py
+++ b/devassistant/settings.py
@@ -92,3 +92,5 @@ SYSTEM_DEPTYPES_SHORTCUTS = {'rpm': ['fedora', 'red hat enterprise linux', 'redh
                              'homebrew': ['darwin', 'OS X']}
 
 DAPI_API_URL = os.environ.get('DAPI_API_URL', 'https://dapi.devassistant.org/api/')
+# TODO Maybe get a better address in the future
+DAPI_API_MIRROR_URL = os.environ.get('DAPI_API_URL', 'https://mirror-devassistant.rhcloud.com/api/')


### PR DESCRIPTION
For now this only works with the API calls, because the URL of a DAP file does not contain API URL and working out the download URL form the API URL might get messy.

In the future, we might need to use some external cloud service to upload the DAPs to anyway (such as when uploading pictures to GitHub issues). 