### PR TITLE
Install to first data directory when NO_DEFAULT_PATH

### DIFF
--- a/devassistant/dapi/dapicli.py
+++ b/devassistant/dapi/dapicli.py
@@ -24,8 +24,9 @@ except:
 from devassistant.settings import DAPI_API_URL
 from devassistant.settings import DAPI_API_MIRROR_URL
 from devassistant.settings import DATA_DIRECTORIES
-from devassistant.settings import DEVASSISTANT_HOME
 from devassistant.settings import DISTRO_DIRECTORY
+from devassistant.settings import INSTALL_DIRECTORY
+
 
 BASIC_LABELS = ['license', 'homepage', 'bugreports']
 EXTRA_LABELS = ['is_pre', 'is_latest', 'is_latest_stable', 'reports']
@@ -37,7 +38,7 @@ def _api_url(mirror=False):
 
 
 def _install_path():
-    return DEVASSISTANT_HOME
+    return INSTALL_DIRECTORY
 
 
 def _data_dirs():

--- a/devassistant/settings.py
+++ b/devassistant/settings.py
@@ -49,8 +49,9 @@ if 'DEVASSISTANT_NO_DEFAULT_PATH' not in os.environ:
     DEVASSISTANT_HOME = DATA_DIRECTORIES[0]
     # Distro directory is where e.g. RPM packages are installed, i.e. /usr/share/devassistant/
     DISTRO_DIRECTORY = DATA_DIRECTORIES[-1]
-elif 'DEVASSISTANT_HOME' not in os.environ:
-    logging.error('DEVASSISTANT_HOME must be defined with DEVASSISTANT_NO_DEFAULT_PATH')
+elif 'DEVASSISTANT_HOME' not in os.environ or 'DEVASSISTANT_PATH' not in os.environ:
+    logging.error('Both DEVASSISTANT_HOME and DEVASSISTANT_PATH '
+                  'must be defined with DEVASSISTANT_NO_DEFAULT_PATH')
     sys.exit(1)
 else:
     DATA_DIRECTORIES = []
@@ -70,6 +71,12 @@ if 'DEVASSISTANT_PATH' in os.environ:
 # User can also redefine DEVASSISTANT_HOME
 if 'DEVASSISTANT_HOME' in os.environ:
     DEVASSISTANT_HOME = os.path.abspath(os.path.expanduser(os.environ['DEVASSISTANT_HOME']))
+
+# When DEVASSISTANT_NO_DEFAULT_PATH is used, do not install to DA_HOME, but first DATA_DIRECTORY
+if 'DEVASSISTANT_NO_DEFAULT_PATH' in os.environ:
+    INSTALL_DIRECTORY = DATA_DIRECTORIES[0]
+else:
+    INSTALL_DIRECTORY = DEVASSISTANT_HOME
     if DEVASSISTANT_HOME not in DATA_DIRECTORIES:
         DATA_DIRECTORIES.insert(0, DEVASSISTANT_HOME)
 

--- a/docs/user_documentation.rst
+++ b/docs/user_documentation.rst
@@ -326,6 +326,9 @@ used in addition to the default ones. If you want to use only the directories in
 ``DEVASSISTANT_PATH``, define the variable ``DEVASSISTANT_NO_DEFAULT_PATH``. You must then define
 ``DEVASSISTANT_HOME`` too, because its default value is unset in the process.
 
+Also note that with ``DEVASSISTANT_NO_DEFAULT_PATH``, the DAPs are installed into first directory
+from ``DEVASSISTANT_PATH``, not to ``DEVASSISTANT_HOME``.
+
 The ``pkg`` command line action works with multiple directories. 
 
 - running ``install`` always installs to ``DEVASSISTANT_HOME``. However, the installation will not take place if a package of the same name is present in some location specified in ``DEVASSISTANT_PATH`` - to override this behavior, use the ``--reinstall`` option.

--- a/test/integration/misc.py
+++ b/test/integration/misc.py
@@ -130,6 +130,9 @@ def environ(*args, **kwargs):
         return {}
     path = ':'.join([str(x) for x in args[1:]])
 
+    if 'dont_put_home' not in kwargs or not kwargs['dont_put_home']:
+        path = home + ':' + path
+
     return {
             'DEVASSISTANT_NO_DEFAULT_PATH': '1',
             'DEVASSISTANT_HOME': home,

--- a/test/integration/test_dapi_integration.py
+++ b/test/integration/test_dapi_integration.py
@@ -114,6 +114,18 @@ class TestDAPIIntegration(object):
         res = run_da('pkg install ' + foo, environ=environ(extra))
         res = res.run_da('pkg uninstall foo --all-paths --force', environ=environ(home, extra))
 
+    def test_install_paths(self, tmpdir):
+        '''Test where are DAPs being installed with DEVASSISTANT_NO_DEFAULT_PATH'''
+        foo = dap_path('meta_only/foo-1.0.0.dap')
+        home = tmpdir.mkdir('home')
+        path = tmpdir.mkdir('path')
+        e = environ(home, path, dont_put_home=True)
+
+        res = run_da('pkg install ' + foo, environ=e)
+        res = res.run_da('pkg list')
+        assert str(path) in res.stdout
+        assert not str(home) in res.stdout
+
     @pytest.mark.webtest
     def test_install_dapi(self):
         res = run_da('pkg install common_args')


### PR DESCRIPTION
When DEVASSISTANT_NO_DEFAULT_PATH is set install DAPs into first
directory from DEVASSISTANT_PATH, not to DEVASSISTANT_HOME

Fixes #378