### PR TITLE
cli_runner.py: Use colorama to render ANSI

### DIFF
--- a/devassistant/cli/cli_runner.py
+++ b/devassistant/cli/cli_runner.py
@@ -3,6 +3,13 @@ import os
 import sys
 import six
 
+try:
+    # stdout/stdrr wrapper to render ANSI sequences in Windows
+    import colorama
+    colorama.init()
+except ImportError:
+    pass
+
 from devassistant import actions
 from devassistant import bin
 from devassistant.cli import argparse_generator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 PyGithub>=1.14.2
 PyYAML
+colorama
 dapp
 jinja2
 progress


### PR DESCRIPTION
This makes devassistant output readable on Windows